### PR TITLE
Do not use Math.random()

### DIFF
--- a/bitcoinjs-lib/src/jsbn/rng.js
+++ b/bitcoinjs-lib/src/jsbn/rng.js
@@ -41,11 +41,14 @@ if(rng_pool == null) {
         for(t = 0; t < word_array.length; ++t)
             rng_seed_int(word_array[t]);
     } else {
-        while(rng_pptr < rng_psize) {  // extract some randomness from Math.random()
-            t = Math.floor(65536 * Math.random());
-            rng_pool[rng_pptr++] = t >>> 8;
-            rng_pool[rng_pptr++] = t & 255;
-        }
+        alert('Your browser does not support crypto secured PRNG!');
+        return;
+
+//        while(rng_pptr < rng_psize) {  // extract some randomness from Math.random()
+//            t = Math.floor(65536 * Math.random());
+//            rng_pool[rng_pptr++] = t >>> 8;
+//            rng_pool[rng_pptr++] = t & 255;
+//        }
     }
 
     rng_pptr = 0;

--- a/bitcoinjs.js
+++ b/bitcoinjs.js
@@ -3088,11 +3088,14 @@ if(rng_pool == null) {
         for(t = 0; t < word_array.length; ++t)
             rng_seed_int(word_array[t]);
     } else {
-        while(rng_pptr < rng_psize) {  // extract some randomness from Math.random()
-            t = Math.floor(65536 * Math.random());
-            rng_pool[rng_pptr++] = t >>> 8;
-            rng_pool[rng_pptr++] = t & 255;
-        }
+        alert('Your browser does not support crypto secured PRNG!');
+        return;
+
+//        while(rng_pptr < rng_psize) {  // extract some randomness from Math.random()
+//            t = Math.floor(65536 * Math.random());
+//            rng_pool[rng_pptr++] = t >>> 8;
+//            rng_pool[rng_pptr++] = t & 255;
+//        }
     }
 
     rng_pptr = 0;


### PR DESCRIPTION
As we know, `Math.random` of JS is **predictable PRNG**. Developers should never use it to generate the Bitcoin private keys.

There are so many browsers, and blockchain.info does not need to support all of them.

The codes that I commited will only prompt an information for users to change their brower, and blockchain.info should modify these codes to user-friendly notice.
