### PR TITLE
Expose webSocketConnect to be able to restart the WebSocket

### DIFF
--- a/wallet.js
+++ b/wallet.js
@@ -2580,6 +2580,10 @@ var MyWallet = new function() {
         $('#large-summary').show();
     }
 
+    this.connectWebSocket = function() {
+        webSocketConnect(wsSuccess);
+    }
+
     this.quickSendNoUI = function(to, value, listener) {
         loadScript('wallet/signer', function() {
             MyWallet.getSecondPassword(function() {


### PR DESCRIPTION
Expose webSocketConnect to have the ability to restart the WebSocket with wallet.js internal wsSuccess function - this is needed for the iOS Wallet because of crashes related to WebSocket usage and the iOS JavaScript interpreter
