### PR TITLE
Fixes off-by-one error in rng.js

### DIFF
--- a/bitcoinjs-lib/src/jsbn/rng.js
+++ b/bitcoinjs-lib/src/jsbn/rng.js
@@ -12,8 +12,8 @@ var has_seeded_large_seed;
 // Mix in integer of n bits into the pool
 function rng_seed_int(x, n) {
     if (!n) n = 32;
-    for (var i = 0; i <= n-8; i += 8) {
-        if (x >> i) rng_pool[rng_pptr++] ^= (x >> i) & 255;
+    for (var i = 0; i < n-8; i += 8) {
+        if (x >>> i) rng_pool[rng_pptr++] ^= (x >>> i) & 255;
         if (rng_pptr >= rng_psize) rng_pptr -= rng_psize;
     }
 }


### PR DESCRIPTION
Line 15 was an off-by-one error that tries to read an unused extra byte when n%8 == 0. Line 16 would have successfully read that byte (as 255) when x's high bit was 1, because the >> operator converts to 32-bit signed and preserves the sign. Without this bugfix, zeroing rng_pool and then calling `for (var i=0; i<rng_psize/4; i++) {rng_seed_int(anyTypeIntegerWith32RandomLowBits(), 32); }` would leave about 1/10 of bytes equal to 255.